### PR TITLE
fix: use esm import to fix ncc build with actions/core v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const core = require('@actions/core');
-const github = require('@actions/github');
+import * as core from '@actions/core';
+import * as github from '@actions/github';
 
 try {
   // Fetch the value of the input 'who-to-greet' specified in action.yml


### PR DESCRIPTION
Fixes the build issue in GitHub actions caused by using `require()` instead of `import` for ES Module packages (@actions/core and @actions/github).